### PR TITLE
Added environment variable

### DIFF
--- a/user.service
+++ b/user.service
@@ -3,6 +3,7 @@ Description=The Lounge IRC client
 
 [Service]
 Type=simple
+Environment=THELOUNGE_HOME=~/.thelounge
 ExecStart=/usr/bin/thelounge start
 
 [Install]


### PR DESCRIPTION
User service needs to define the environment variable in order to override the .thelounge_home file.