### PR TITLE
Fix network not available on boot

### DIFF
--- a/system.service
+++ b/system.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Lounge IRC client
-After=network.target
+After=network-online.target
 
 [Service]
 User=thelounge


### PR DESCRIPTION
Very often, on boot, TheLounge cannot connect to channels because network is not available yet. Use network-online.target solves the problem.