### PR TITLE
Fix systemd-tmpfiles bad permissions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,20 +19,22 @@ source=(
 )
 noextract=("$pkgname-$pkgver.tgz")
 sha256sums=('c4058bb9db0ef94480203f88c3d989945c2df0a5636ba3637040ef3e58237846'
-            'c92210f6ac8f01c1cd01b6b26793094cd2feea583ed21fab3564d6bcafdc7a20'
+            '8816c0b871689519f1614dce1805fde9924c03e2ca3d836902f56536ada93840'
             'c609f3309f54bd6285e99ff29ca2464828bec7bbbca67243ee688bd2d605dbf0'
             '30fab63b8a4ffcfdda4c5b8d7c66822a323c4f1de6ca62b77fe9500f4befc0a5'
-            '4060efc92346c7193e699ffe1b802d85dc45daa7b5260ecdf70a6b993c30b01a')
+            '1cac32233da5c8eee576b43fd28cadd29ac3f79cdfdcc94fbb2a4ae529f4f146')
 
 package() {
     export NODE_ENV=production
 
     npm install -g --user root --prefix "$pkgdir/usr" "$pkgname-$pkgver.tgz" --cache "${srcdir}/npm-cache"
 
-    echo /etc/thelounge > "$pkgdir/usr/lib/node_modules/$pkgname/.thelounge_home"
+    echo /etc/thelounge/home > "$pkgdir/usr/lib/node_modules/$pkgname/.thelounge_home"
 
     # add default config
     install -Dm 644 "$pkgdir/usr/lib/node_modules/$pkgname/defaults/config.js" "$pkgdir/etc/thelounge/config.js"
+    mkdir "$pkgdir/etc/thelounge/home"
+    ln -s "../config.js" "$pkgdir/etc/thelounge/home/config.js"
 
     # services
     install -Dm644 "$srcdir/system.service" "$pkgdir/usr/lib/systemd/system/$pkgname.service"

--- a/system.service
+++ b/system.service
@@ -6,10 +6,10 @@ After=network.target
 User=thelounge
 Group=thelounge
 Type=simple
-Environment=THELOUNGE_HOME=/etc/thelounge
+Environment=THELOUNGE_HOME=/etc/thelounge/home
 ExecStart=/usr/bin/thelounge start
 ProtectSystem=strict
-ReadWritePaths=/etc/thelounge
+ReadWritePaths=/etc/thelounge/home
 ProtectHome=yes
 NoNewPrivileges=yes
 PrivateTmp=yes

--- a/tmpfiles.d
+++ b/tmpfiles.d
@@ -1,5 +1,4 @@
 #Type Path        Mode UID  GID  Age Argument
-d /etc/thelounge 0755 thelounge thelounge
-d /etc/thelounge/users 0755 thelounge thelounge
-z "/etc/thelounge/users/*" 0640 thelounge thelounge
-z /etc/thelounge/config.js - thelounge thelounge
+d /etc/thelounge 0755 root root
+z /etc/thelounge/config.js - root root
+d /etc/thelounge/home 0750 thelounge thelounge


### PR DESCRIPTION
thelounge:thelounge owns /etc/thelounge, but
root:root owns /etc/thelounge/config.js which systemd-tmpfiles does not like.

Now,
THELOUNGE_HOME=/etc/thelounge/home
root:root owns /etc/thelounge
root:root owns /etc/thelounge/config.js
thelounge:thelounge owns /etc/thelounge/home

:: Running post-transaction hooks...
(1/4) Creating system user accounts...
(2/4) Reloading system manager configuration...
(3/4) Creating temporary files...
error: command failed to execute correctly
(4/4) Arming ConditionNeedsUpdate...

$ sudo /usr/bin/systemd-tmpfiles --create
Detected unsafe path transition /etc/thelounge -> /etc/thelounge/config.js during canonicalization of /etc/thelounge/config.js.